### PR TITLE
add cohort model

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -1,0 +1,7 @@
+class Cohort < ActiveRecord::Base
+  validates :start_date, presence: true
+  validates :end_date, presence: true
+  validates :description, presence: true
+  
+  has_many :users
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   validates :plan_id, presence: true
 
   belongs_to :plan
+  belongs_to :cohort
   has_one :bank_account
   has_many :payments, through: :bank_account
   has_many :attendance_records

--- a/db/migrate/20141013223159_create_cohorts.rb
+++ b/db/migrate/20141013223159_create_cohorts.rb
@@ -1,0 +1,13 @@
+class CreateCohorts < ActiveRecord::Migration
+  def change
+    create_table :cohorts do |t|
+      t.string :description
+      t.date :start_date
+      t.date :end_date
+
+      t.timestamps
+    end
+
+    add_column :users, :cohort_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141007221803) do
+ActiveRecord::Schema.define(version: 20141013223159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "assessments", force: true do |t|
+    t.string   "title"
+    t.string   "section"
+    t.string   "url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "attendance_records", force: true do |t|
     t.integer  "user_id"
@@ -30,6 +38,25 @@ ActiveRecord::Schema.define(version: 20141007221803) do
     t.integer  "user_id"
     t.boolean  "verified"
     t.boolean  "recurring_active"
+  end
+
+  create_table "cohorts", force: true do |t|
+    t.string   "description"
+    t.date     "start_date"
+    t.date     "end_date"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "grades", force: true do |t|
+    t.integer  "submission_id"
+    t.integer  "requirement_id"
+    t.string   "comment"
+    t.integer  "score"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "user_id"
+    t.integer  "review_id"
   end
 
   create_table "payments", force: true do |t|
@@ -49,6 +76,28 @@ ActiveRecord::Schema.define(version: 20141007221803) do
     t.datetime "updated_at"
   end
 
+  create_table "requirements", force: true do |t|
+    t.string   "content"
+    t.integer  "assessment_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "reviews", force: true do |t|
+    t.integer  "submission_id"
+    t.integer  "user_id"
+    t.text     "note"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "submissions", force: true do |t|
+    t.integer "user_id"
+    t.string  "link"
+    t.text    "note"
+    t.integer "assessment_id"
+  end
+
   create_table "users", force: true do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
@@ -64,6 +113,7 @@ ActiveRecord::Schema.define(version: 20141007221803) do
     t.datetime "updated_at"
     t.string   "name"
     t.integer  "plan_id"
+    t.integer  "cohort_id"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -1,0 +1,9 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :cohort do
+    description "Current cohort"
+    start_date Date.today
+    end_date Date.today + 15.weeks
+  end
+end

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe Cohort do
+  it { should have_many :users }
+  it { should validate_presence_of :start_date }
+  it { should validate_presence_of :end_date }
+  it { should validate_presence_of :description }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,7 @@ describe User do
   it { should have_many :payments }
   it { should belong_to :plan }
   it { should have_many :attendance_records }
+  it { should belong_to :cohort }
 
   describe '#signed_in_today?' do
     let(:user) { FactoryGirl.create(:user) }
@@ -14,7 +15,7 @@ describe User do
     it 'is false if the user has not signed in today' do
       expect(user.signed_in_today?).to eq false
     end
-    
+
     it 'is true if the user has already signed in today' do
       attendance_record = FactoryGirl.create(:attendance_record, user: user)
       expect(user.signed_in_today?).to eq true


### PR DESCRIPTION
This represents the different classes, such as 'Winter 2015'. `Cohort` was chosen because of the potential confusion with names like `Class` or `Session`.
