### PR TITLE
fix attendance_record uniqueness validation

### DIFF
--- a/app/models/attendance_record.rb
+++ b/app/models/attendance_record.rb
@@ -1,5 +1,5 @@
 class AttendanceRecord < ActiveRecord::Base
-  scope :today, -> { where(created_at: (Date.today.beginning_of_day..Date.today.end_of_day)) }
+  scope :today, -> { where(created_at: (Time.now.utc.beginning_of_day..Time.now.utc.end_of_day)) }
   validates :user_id, presence: true, uniqueness: { conditions: -> { today } }
 
   after_validation :set_tardiness


### PR DESCRIPTION
In an attempt to refactor the original solution for this, we instead broke it. We didn't know because we didn't test it after 5pm. I am officially deeming this the gremlin bug, because it only shows up after midnight (utc). This commit kills the gremlin, so all is right in the world.
