### PR TITLE
add belongs_to association on assessments to cohorts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,9 +12,9 @@ protected
 
   def after_sign_in_path_for(user)
     if user.is_a? Admin
-      assessments_path
+      cohort_assessments_path(user.current_cohort)
     elsif user.is_a? Student
-      user.class_in_session? ? assessments_path : class_not_in_session(user)
+      user.class_in_session? ? cohort_assessments_path(user.cohort) : class_not_in_session(user)
     end
   end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -2,7 +2,7 @@ class AssessmentsController < ApplicationController
   authorize_resource
 
   def index
-    @assessments = Assessment.all
+    @assessments = Cohort.find(params[:cohort_id]).assessments
   end
 
   def new
@@ -40,12 +40,12 @@ class AssessmentsController < ApplicationController
   def destroy
     @assessment = Assessment.find(params[:id])
     @assessment.destroy
-    redirect_to assessments_path, alert: "#{@assessment.title} has been deleted."
+    redirect_to cohort_assessments_path(current_admin.current_cohort), alert: "#{@assessment.title} has been deleted."
   end
 
 private
 
   def assessment_params
-    params.require(:assessment).permit(:title, :section, :url, requirements_attributes: [:id, :content, :_destroy])
+    params.require(:assessment).permit(:title, :section, :url, requirements_attributes: [:id, :content, :_destroy]).merge(cohort_id: current_admin.current_cohort.id)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,7 +10,7 @@ class Ability
       can :create, Review
       can :read, CohortAttendanceStatistics
     elsif user.is_a? Student
-      can :read, Assessment
+      can :read, Assessment, cohort_id: user.cohort_id
       can :create, Submission
       can :update, Submission, student_id: user.id
       can :create, BankAccount

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,3 +1,11 @@
 class Admin < User
   belongs_to :current_cohort, class_name: 'Cohort'
+
+  before_create :assign_current_cohort
+
+private
+
+  def assign_current_cohort
+    self.current_cohort = Cohort.last
+  end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -1,9 +1,11 @@
 class Assessment < ActiveRecord::Base
   validates_presence_of :title, :section, :url
   validate :presence_of_requirements
+  validates :cohort_id, presence: true
 
   has_many :requirements
   has_many :submissions
+  belongs_to :cohort
 
   accepts_nested_attributes_for :requirements, reject_if: :attributes_blank?, allow_destroy: true
 

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -5,6 +5,7 @@ class Cohort < ActiveRecord::Base
 
   has_many :students
   has_many :attendance_records, through: :students
+  has_many :assessments
 
   def number_of_days_since_start
     last_date = Date.today <= end_date ? Date.today : end_date

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -3,7 +3,7 @@
     <ul class="nav pull-right">
       <% if current_student %>
         <li><%= link_to 'Payments', payments_path %></li>
-        <li><%= link_to 'Assessments', assessments_path %></li>
+        <li><%= link_to 'Assessments', cohort_assessments_path(current_student.cohort) %></li>
         <li><%= link_to 'Attendance record', attendance_statistics_path %></li>
         <li><%= link_to 'Profile', edit_student_registration_path %></li>
         <li><%= link_to "Log out", destroy_student_session_path, data: { method: :delete }, class: 'log-in' %></li>
@@ -19,7 +19,7 @@
             <% end %>
           </ul>
         </li>
-        <li><%= link_to 'Assessments', assessments_path %></li>
+        <li><%= link_to 'Assessments', cohort_assessments_path(current_admin.current_cohort) %></li>
         <li><%= link_to 'Attendance statistics', cohort_attendance_statistics_path(current_admin.current_cohort) %></li>
         <li><%= link_to "Log out", destroy_admin_session_path, data: { method: :delete }, class: 'log-in' %></li>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,17 +19,16 @@ Rails.application.routes.draw do
   resources :attendance_records, only: [:create, :destroy]
   resources :cohorts, only: [] do
     resources :attendance_statistics, only: [:index]
+    resources :assessments, only: [:index]
   end
 
   resource :attendance_statistics, only: [:show]
 
-  resources :assessments do
+  resources :assessments, except: [:index] do
     resources :submissions, only: [:index, :create, :update]
   end
 
   resources :submissions, only: [] do
     resources :reviews, only: [:new, :create]
   end
-
-  resources :assessments
 end

--- a/db/migrate/20141113204346_add_cohort_id_to_assessments.rb
+++ b/db/migrate/20141113204346_add_cohort_id_to_assessments.rb
@@ -1,0 +1,5 @@
+class AddCohortIdToAssessments < ActiveRecord::Migration
+  def change
+    add_column :assessments, :cohort_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141112193218) do
+ActiveRecord::Schema.define(version: 20141113204346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20141112193218) do
     t.string   "url"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "cohort_id"
   end
 
   create_table "attendance_records", force: true do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -166,6 +166,7 @@ FactoryGirl.define do
     title 'assessment title'
     section 'object oriented design'
     url 'http://learnhowtoprogram.com'
+    cohort
 
     before(:create) do |assessment|
       assessment.requirements << build(:requirement)

--- a/spec/features/admin_pages_spec.rb
+++ b/spec/features/admin_pages_spec.rb
@@ -41,4 +41,17 @@ feature 'Changing current cohort', js: true do
       expect(page).to have_content student.name
     end
   end
+
+  context 'when viewing a cohort assessments page' do
+    it 'redirects them to the assessments for their current cohort' do
+      cohort = FactoryGirl.create(:cohort, description: 'Winter 2015')
+      assessment = FactoryGirl.create(:assessment, cohort: cohort)
+      login_as(admin, scope: :admin)
+      visit cohort_assessments_path(admin.current_cohort)
+      expect(page).to_not have_content assessment.title
+      click_link admin.current_cohort.description
+      click_link cohort.description
+      expect(page).to have_content assessment.title
+    end
+  end
 end

--- a/spec/features/assessments_pages_spec.rb
+++ b/spec/features/assessments_pages_spec.rb
@@ -1,24 +1,25 @@
 feature 'index page' do
+  let!(:assessment) { FactoryGirl.create(:assessment) }
+
   scenario 'not logged in' do
-    visit assessments_path
+    visit cohort_assessments_path(assessment.cohort)
     expect(page).to have_content 'need to sign in'
   end
 
   context 'when visiting as a student' do
     let(:student) { FactoryGirl.create(:student) }
-    let!(:assessment) { FactoryGirl.create(:assessment) }
     before { login_as(student, scope: :student) }
 
     scenario 'shows all assessments' do
-      another_assessment = FactoryGirl.create(:assessment, title: 'another_assessment')
-      visit assessments_path
+      another_assessment = FactoryGirl.create(:assessment, title: 'another_assessment', cohort: assessment.cohort)
+      visit cohort_assessments_path(assessment.cohort)
       expect(page).to have_content assessment.title
       expect(page).to have_content another_assessment.title
     end
 
     scenario 'shows if the student has submitted an assessment' do
       FactoryGirl.create(:submission, assessment: assessment, student: student)
-      visit assessments_path
+      visit cohort_assessments_path(assessment.cohort)
       expect(page).to have_content 'Submitted'
       expect(page).to_not have_content 'Not submitted'
     end
@@ -26,13 +27,13 @@ feature 'index page' do
     scenario 'shows if the assessment has been graded' do
       submission = FactoryGirl.create(:submission, assessment: assessment, student: student)
       FactoryGirl.create(:review, submission: submission)
-      visit assessments_path
+      visit cohort_assessments_path(assessment.cohort)
       expect(page).to have_content 'Reviewed'
       expect(page).to_not have_content 'Submitted'
     end
 
     scenario 'links to assessment show page' do
-      visit assessments_path
+      visit cohort_assessments_path(assessment.cohort)
       click_link assessment.title
       expect(page).to have_content assessment.title
       expect(page).to have_content assessment.requirements.first.content
@@ -46,20 +47,20 @@ feature 'index page' do
     before { login_as(admin, scope: :admin) }
 
     scenario 'has a link to create a new assessment' do
-      visit assessments_path
+      visit cohort_assessments_path(assessment.cohort)
       click_on 'Add an assessment'
       expect(page).to have_content 'New Assessment'
     end
 
     scenario 'shows the number of submissions needing review for each assessment' do
       FactoryGirl.create(:submission, assessment: assessment)
-      visit assessments_path
+      visit cohort_assessments_path(assessment.cohort)
       expect(page).to have_content '1 new submission'
     end
 
     scenario 'admin clicks on number of submission badge and is taken to submissions index of that assessment' do
       FactoryGirl.create(:submission, assessment: assessment)
-      visit assessments_path
+      visit cohort_assessments_path(assessment.cohort)
       click_link '1 new submission'
       expect(page).to have_content "Submissions for #{assessment.title}"
     end

--- a/spec/features/students_pages_spec.rb
+++ b/spec/features/students_pages_spec.rb
@@ -75,7 +75,7 @@ feature "Student signs in while class is in session" do
 
   it "takes them to the assessments page" do
     sign_in(student)
-    expect(current_path).to eq assessments_path
+    expect(current_path).to eq cohort_assessments_path(student.cohort)
     expect(page).to have_content "Assessments"
   end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -38,4 +38,11 @@ describe Admin do
       it { is_expected.to not_have_abilities(:update, Verification.new) }
     end
   end
+
+  it 'is assigned a default current_cohort before creation' do
+    FactoryGirl.create(:cohort)
+    admin = FactoryGirl.build(:admin, current_cohort: nil)
+    admin.save
+    expect(admin.current_cohort).to be_a Cohort
+  end
 end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -2,8 +2,10 @@ describe Assessment do
   it { should validate_presence_of :title }
   it { should validate_presence_of :section }
   it { should validate_presence_of :url }
+  it { should validate_presence_of :cohort_id }
   it { should have_many :requirements }
   it { should have_many :submissions }
+  it { should belong_to :cohort }
   it { should accept_nested_attributes_for :requirements }
 
   it 'validates presence of at least one requirement' do

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -1,6 +1,7 @@
 describe Cohort do
   it { should have_many :students }
   it { should have_many(:attendance_records).through(:students) }
+  it { should have_many :assessments }
   it { should validate_presence_of :description }
   it { should validate_presence_of :start_date }
   it { should validate_presence_of :end_date }

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -386,7 +386,8 @@ describe Student do
     subject { Ability.new(student) }
 
     context 'for assessments' do
-      it { is_expected.to have_abilities(:read, Assessment.new) }
+      it { is_expected.to have_abilities(:read, Assessment.new(cohort: student.cohort)) }
+      it { is_expected.to not_have_abilities(:read, Assessment.new) }
     end
 
     context 'for submissions' do


### PR DESCRIPTION
We realized that like attendance records, assessments needed to be
scoped within certain cohorts. We could end up with multiple cohorts
that each have completely different assessments. This allows us to
show students just the assesments that are pertinent to them. This
also sets permissions that do not allow students to view assessments
of other cohorts.

The current_cohort switching for admins now also applies to assessments.
When an admin goes to view assessments, it will be for their current
cohort. They can easily switch using the cohort dropdown in the navbar.
Also, when assessments are created or updated, they will belong to
whatever the admin's current cohort is.
