### PR TITLE
create transcripts for students

### DIFF
--- a/app/assets/stylesheets/core.css
+++ b/app/assets/stylesheets/core.css
@@ -300,3 +300,23 @@ a .badge:hover {
 .edit_cohort a.btn-danger {
   margin-top: 20px;
 }
+
+.transcript {
+  margin-top: 20px;
+}
+
+.transcript h1 {
+  font-size: 250%;
+  margin-bottom: -20px;
+}
+.transcript h2 {
+  font-size: 200%;
+}
+
+.transcript p, .transcript li {
+  color: #333;
+}
+
+.transcript hr {
+  border-color: #999;
+}

--- a/app/controllers/transcripts_controller.rb
+++ b/app/controllers/transcripts_controller.rb
@@ -1,0 +1,5 @@
+class TranscriptsController < ApplicationController
+  def show
+    @transcript = Transcript.new(current_student)
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -17,6 +17,10 @@ class Assessment < ActiveRecord::Base
     submissions.find_by(student: student)
   end
 
+  def expectations_met_by?(student)
+    submission_for(student).try(:meets_expectations?)
+  end
+
 private
 
   def set_number

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -9,6 +9,10 @@ class Review < ActiveRecord::Base
 
   after_create :mark_submission_as_reviewed
 
+  def meets_expectations?
+    grades.includes(:score).pluck(:value).all? { |value| value > 1 }
+  end
+
 private
 
   def mark_submission_as_reviewed

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -7,7 +7,6 @@ class Submission < ActiveRecord::Base
   belongs_to :student
   belongs_to :assessment
   has_many :reviews
-  has_one :latest_review, -> { order('created_at DESC') }, class_name: "Review"
 
   before_create :mark_as_needing_review
 
@@ -23,6 +22,14 @@ class Submission < ActiveRecord::Base
       assessment.requirements.each { |requirement| review.grades.build(requirement: requirement) }
       review
     end
+  end
+
+  def latest_review
+    reviews.order('created_at DESC').first
+  end
+
+  def meets_expectations?
+    latest_review.try(:meets_expectations?)
   end
 
 private

--- a/app/models/transcript.rb
+++ b/app/models/transcript.rb
@@ -1,0 +1,26 @@
+class Transcript
+  TARDY_WEIGHT = 0.5
+
+  attr_reader :student
+
+  def initialize(student)
+    @student = student
+  end
+
+  def passing_assessments
+    @student.cohort.assessments.select do |assessment|
+      assessment.expectations_met_by? @student
+    end
+  end
+
+  def attendance_score
+    cohort_days = @student.cohort.total_class_days
+    absences_penalty = @student.absences
+    tardies_penalty = @student.tardies * TARDY_WEIGHT
+    (cohort_days - (absences_penalty + tardies_penalty)) / cohort_days
+  end
+
+  def bottom_of_percentile_range
+    ((attendance_score * 100).to_i / 5) * 5
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,8 @@
 <h1>Profile</h1>
 
 <% if @student.class_over? %>
-  <h2><%= link_to "Print your certificate of completion", certificate_path %></h2>
+  <h2><%= link_to "View certificate of completion", certificate_path, target: '_blank' %></h2>
+  <h2><%= link_to "View transcript", transcript_path, target: '_blank' %></h2>
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
@@ -34,4 +35,3 @@
 <% end %>
 
 <%= link_to "Back", :back %>
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 </head>
 <body>
   <div class="container">
-    <%= render 'layouts/navbar' unless current_page?(certificate_path) %>
+    <%= render 'layouts/navbar' unless current_page?(certificate_path) || current_page?(transcript_path) %>
     <%= flash_notice(flash) do %>
       <%= flash[:notice] %>
       <%= flash[:alert] %>

--- a/app/views/transcripts/show.html.erb
+++ b/app/views/transcripts/show.html.erb
@@ -1,0 +1,26 @@
+<div class="transcript">
+  <h1>Epicodus</h1>
+  <h2>Intensive Web Development</h2>
+  <h2>Transcript</h2>
+
+  <p>
+    Student: <%= @transcript.student.name %><br>
+    Class: <%= @transcript.student.cohort.description %>
+  </p>
+
+  <hr>
+
+  <p>Student has met course expecations in these areas:</p>
+  <ul>
+    <% @transcript.passing_assessments.each do |assessment| %>
+      <li><%= assessment.title %></li>
+    <% end %>
+  </ul>
+
+  <hr>
+  <h3>Attendance</h3>
+  <p>
+    <%= @transcript.student.name %> was present
+    <%= @transcript.bottom_of_percentile_range %>% - <%= @transcript.bottom_of_percentile_range + 5 %>%
+    of the time.</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   end
   resource :credit_card, only: [:new, :create]
   resource :certificate, only: [:show]
+  resource :transcript, only: [:show]
   resources :payments, only: [:index]
   resources :upfront_payments, only: [:create]
   resources :recurring_payments, only: [:create]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,6 +35,19 @@ ActiveRecord::Schema.define(version: 20141117223210) do
   add_index "attendance_records", ["student_id"], name: "index_attendance_records_on_student_id", using: :btree
   add_index "attendance_records", ["tardy"], name: "index_attendance_records_on_tardy", using: :btree
 
+  create_table "bank_accounts", force: true do |t|
+    t.string   "account_uri"
+    t.string   "verification_uri"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "student_id"
+    t.boolean  "verified"
+    t.string   "last_four_string"
+  end
+
+  add_index "bank_accounts", ["student_id"], name: "index_bank_accounts_on_student_id", using: :btree
+  add_index "bank_accounts", ["verified"], name: "index_bank_accounts_on_verified", using: :btree
+
   create_table "cohorts", force: true do |t|
     t.string   "description"
     t.date     "start_date"
@@ -42,6 +55,16 @@ ActiveRecord::Schema.define(version: 20141117223210) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "credit_cards", force: true do |t|
+    t.string   "credit_card_uri"
+    t.integer  "student_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "last_four_string"
+  end
+
+  add_index "credit_cards", ["student_id"], name: "index_credit_cards_on_student_id", using: :btree
 
   create_table "grades", force: true do |t|
     t.integer  "requirement_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -158,12 +158,19 @@ FactoryGirl.define do
   end
 
   factory :score do
-    value 3
     sequence(:description) { |n| "Meets expectations #{n} of the time" }
+
+    factory :failing_score do
+      value 1
+    end
+
+    factory :passing_score do
+      value 3
+    end
   end
 
   factory :assessment do
-    title 'assessment title'
+    sequence(:title) { |n| "assessment #{n}" }
     cohort
 
     before(:create) do |assessment|
@@ -172,7 +179,13 @@ FactoryGirl.define do
   end
 
   factory :grade do
-    score
+    factory :passing_grade do
+      association :score, factory: :passing_score
+    end
+
+    factory :failing_grade do
+      association :score, factory: :failing_score
+    end
   end
 
   factory :requirement do
@@ -183,9 +196,19 @@ FactoryGirl.define do
     note 'Great job!'
     submission
 
-    after(:create) do |review|
-      review.submission.assessment.requirements.each do |requirement|
-        FactoryGirl.create(:grade, review: review, requirement: requirement)
+    factory :passing_review do
+      after(:create) do |review|
+        review.submission.assessment.requirements.each do |requirement|
+          FactoryGirl.create(:passing_grade, review: review, requirement: requirement)
+        end
+      end
+    end
+
+    factory :failing_review do
+      after(:create) do |review|
+        review.submission.assessment.requirements.each do |requirement|
+          FactoryGirl.create(:failing_grade, review: review, requirement: requirement)
+        end
       end
     end
   end

--- a/spec/features/assessments_pages_spec.rb
+++ b/spec/features/assessments_pages_spec.rb
@@ -32,7 +32,7 @@ feature 'index page' do
 
     scenario 'shows if the assessment has been graded' do
       submission = FactoryGirl.create(:submission, assessment: assessment, student: student)
-      FactoryGirl.create(:review, submission: submission)
+      FactoryGirl.create(:passing_review, submission: submission)
       visit cohort_assessments_path(assessment.cohort)
       expect(page).to have_content 'Reviewed'
       expect(page).to_not have_content 'Submitted'
@@ -170,7 +170,7 @@ feature 'show page' do
 
     context 'after submission has been reviewed' do
       let(:submission) { FactoryGirl.create(:submission, assessment: assessment, student: student) }
-      let!(:review) { FactoryGirl.create(:review, submission: submission) }
+      let!(:review) { FactoryGirl.create(:passing_review, submission: submission) }
 
       before do
         visit assessment_path(assessment)
@@ -185,7 +185,7 @@ feature 'show page' do
       let(:submission) { FactoryGirl.create(:submission, assessment: assessment, student: student) }
 
       before do
-        FactoryGirl.create(:review, submission: submission)
+        FactoryGirl.create(:passing_review, submission: submission)
         visit assessment_path(assessment)
         click_on 'Resubmit'
       end

--- a/spec/features/certificate_pages_spec.rb
+++ b/spec/features/certificate_pages_spec.rb
@@ -4,7 +4,7 @@ feature "print completion certificate" do
       student = FactoryGirl.create(:student)
       login_as(student, scope: :student)
       visit edit_student_registration_path
-      expect(page).to_not have_link "Print your certificate of completion"
+      expect(page).to_not have_link "View your certificate of completion"
     end
   end
 
@@ -14,7 +14,7 @@ feature "print completion certificate" do
       student = FactoryGirl.create(:student, cohort: cohort)
       login_as(student, scope: :student)
       visit edit_student_registration_path
-      click_link "Print your certificate of completion"
+      click_link "View certificate of completion"
       expect(page).to have_content "Certificate of Completion for Epicodus"
       expect(page).to have_content student.name
     end

--- a/spec/features/submission_pages_spec.rb
+++ b/spec/features/submission_pages_spec.rb
@@ -23,7 +23,7 @@ feature 'index page' do
 
     scenario 'lists only submissions needing review' do
       reviewed_submission = FactoryGirl.create(:submission, assessment: assessment, student: student)
-      FactoryGirl.create(:review, submission: reviewed_submission)
+      FactoryGirl.create(:passing_review, submission: reviewed_submission)
       visit assessment_submissions_path(assessment)
       expect(page).to_not have_content reviewed_submission.student.name
     end
@@ -58,7 +58,7 @@ feature 'index page' do
       context 'creating a review', js: true do
         let(:admin) { FactoryGirl.create(:admin) }
         let!(:submission) { FactoryGirl.create(:submission, assessment: assessment, student: student) }
-        let!(:score) { FactoryGirl.create(:score) }
+        let!(:score) { FactoryGirl.create(:passing_score) }
 
         before do
           login_as(admin, scope: :admin)
@@ -80,7 +80,7 @@ feature 'index page' do
         end
 
         context 'when the submission has been reviewed before' do
-          let!(:review) { FactoryGirl.create(:review, submission: submission) }
+          let!(:review) { FactoryGirl.create(:passing_review, submission: submission) }
 
           before { submission.update(needs_review: true) }
 

--- a/spec/features/transcript_pages_spec.rb
+++ b/spec/features/transcript_pages_spec.rb
@@ -1,0 +1,44 @@
+feature "viewing transcript" do
+  context "before class is over" do
+    it "doesn't show link to print certificate" do
+      student = FactoryGirl.create(:student)
+      login_as(student, scope: :student)
+      visit edit_student_registration_path
+      expect(page).to_not have_link "View/print transcript"
+    end
+  end
+
+  context "after class ends" do
+    it "allows student to view their transcript" do
+      cohort = FactoryGirl.create(:past_cohort)
+      student = FactoryGirl.create(:student, cohort: cohort)
+      login_as(student, scope: :student)
+      visit edit_student_registration_path
+      click_link "View transcript"
+      expect(page).to have_content "Transcript"
+      expect(page).to have_content student.name
+    end
+
+    it 'shows a breakdown of how they did on each assessment' do
+      cohort = FactoryGirl.create(:past_cohort)
+      student = FactoryGirl.create(:student, cohort: cohort)
+      assessment = FactoryGirl.create(:assessment, cohort: cohort)
+      not_taken_assessment = FactoryGirl.create(:assessment, cohort: cohort)
+      submission = FactoryGirl.create(:submission, assessment: assessment, student: student)
+      review = FactoryGirl.create(:passing_review, submission: submission)
+
+      login_as(student, scope: :student)
+      visit transcript_path
+      expect(page).to have_content assessment.title
+      expect(page).to_not have_content not_taken_assessment.title
+    end
+
+    it 'shows a summary of their attendance record' do
+      cohort = FactoryGirl.create(:past_cohort)
+      student = FactoryGirl.create(:student, cohort: cohort)
+      login_as(student, scope: :student)
+      visit transcript_path
+      expect(page).to have_content "#{student.name} was present 0% - 5% of the time"
+    end
+  end
+end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -37,4 +37,21 @@ describe Assessment do
       expect(assessment.submission_for(student)).to eq submission
     end
   end
+
+  describe '#exepectations_met_by?' do
+    let(:assessment) { FactoryGirl.create(:assessment) }
+    let(:student) { FactoryGirl.create(:student) }
+
+    it "is true if the student's submission has met expectations" do
+      submission = FactoryGirl.create(:submission, student: student, assessment: assessment)
+      FactoryGirl.create(:passing_review, submission: submission)
+      expect(assessment.expectations_met_by?(student)).to eq true
+    end
+
+    it "is false if the student's submission has not met expectations" do
+      submission = FactoryGirl.create(:submission, student: student, assessment: assessment)
+      FactoryGirl.create(:failing_review, submission: submission)
+      expect(assessment.expectations_met_by?(student)).to eq false
+    end
+  end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -7,8 +7,20 @@ describe Review do
   describe 'on creation' do
     it 'updates the submission needs review to false' do
       submission = FactoryGirl.create(:submission)
-      review = FactoryGirl.create(:review, submission: submission)
+      review = FactoryGirl.create(:passing_review, submission: submission)
       expect(submission.needs_review).to eq false
+    end
+  end
+
+  describe '#meets_expectations?' do
+    it "is true if the review's scores are all above 1" do
+      review = FactoryGirl.create(:passing_review)
+      expect(review.meets_expectations?).to eq true
+    end
+
+    it "is false if any of the review's scores are 1" do
+      review = FactoryGirl.create(:failing_review)
+      expect(review.meets_expectations?).to eq false
     end
   end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -2,7 +2,6 @@ describe Submission do
   it { should validate_presence_of :link }
   it { should belong_to :assessment }
   it { should have_many :reviews }
-  it { should have_one :latest_review }
   it { should belong_to :student }
   it { should validate_uniqueness_of(:student_id).scoped_to(:assessment_id) }
 
@@ -14,7 +13,7 @@ describe Submission do
 
     it 'is false if a review has been created for this submission' do
       submission = FactoryGirl.create(:submission)
-      FactoryGirl.create(:review, submission: submission)
+      FactoryGirl.create(:passing_review, submission: submission)
       expect(submission.needs_review?).to eq false
     end
   end
@@ -22,7 +21,7 @@ describe Submission do
   describe '#has_been_reviewed?' do
     it 'is true if submission has been reviewed' do
       submission = FactoryGirl.create(:submission)
-      FactoryGirl.create(:review, submission: submission)
+      FactoryGirl.create(:passing_review, submission: submission)
       expect(submission.has_been_reviewed?).to eq true
     end
   end
@@ -31,8 +30,17 @@ describe Submission do
     it 'returns only submissions still needing review' do
       reviewed_submission = FactoryGirl.create(:submission)
       not_reviewed_submission = FactoryGirl.create(:submission)
-      FactoryGirl.create(:review, submission: reviewed_submission)
+      FactoryGirl.create(:passing_review, submission: reviewed_submission)
       expect(Submission.needing_review).to eq [not_reviewed_submission]
+    end
+  end
+
+  describe '#latest_review' do
+    it 'returns the latest review for this submission' do
+      submission = FactoryGirl.create(:submission)
+      review = FactoryGirl.create(:review, submission: submission)
+      later_review = FactoryGirl.create(:review, submission: submission)
+      expect(submission.latest_review).to eq later_review
     end
   end
 
@@ -48,8 +56,8 @@ describe Submission do
   describe 'latest_review' do
     it 'returns the most recent review for this submissions' do
       submission = FactoryGirl.create(:submission)
-      first_review = FactoryGirl.create(:review, submission: submission)
-      second_review = FactoryGirl.create(:review, submission: submission)
+      first_review = FactoryGirl.create(:passing_review, submission: submission)
+      second_review = FactoryGirl.create(:passing_review, submission: submission)
       expect(submission.latest_review).to eq second_review
     end
   end
@@ -67,11 +75,25 @@ describe Submission do
     end
 
     it 'returns a cloned review object if there is a latest review' do
-      old_review = FactoryGirl.create(:review, submission: submission)
+      old_review = FactoryGirl.create(:passing_review, submission: submission)
       new_review = submission.clone_or_build_review
       expect(new_review.note).to eq old_review.note
       expect(new_review.submission).to eq old_review.submission
       expect(new_review.grades.first.score).to eq old_review.grades.first.score
+    end
+  end
+
+  describe '#meets_expectations?' do
+    let(:submission) { FactoryGirl.create(:submission) }
+
+    it 'is true if the latest review meets expectations' do
+      review = FactoryGirl.create(:passing_review, submission: submission)
+      expect(submission.meets_expectations?).to eq true
+    end
+
+    it 'is false if the latest review does not meet expectations' do
+      FactoryGirl.create(:failing_review, submission: submission)
+      expect(submission.meets_expectations?).to eq false
     end
   end
 end

--- a/spec/models/transcript_spec.rb
+++ b/spec/models/transcript_spec.rb
@@ -1,0 +1,60 @@
+describe Transcript do
+  let(:student) { FactoryGirl.create(:student) }
+
+  it 'initializes with a student' do
+    transcript = Transcript.new(student)
+    expect(transcript).to be_a Transcript
+  end
+
+  describe '#passing_assessments' do
+    it 'returns all the assessments for which the student has met expectations' do
+      passed_assessment = FactoryGirl.create(:assessment, cohort: student.cohort)
+      passed_submission = FactoryGirl.create(:submission, student: student, assessment: passed_assessment)
+      FactoryGirl.create(:passing_review, submission: passed_submission)
+
+      failed_assessment = FactoryGirl.create(:assessment, cohort: student.cohort)
+      failed_submission = FactoryGirl.create(:submission, student: student, assessment: failed_assessment)
+      failed_review = FactoryGirl.create(:passing_review, submission: failed_submission)
+      failing_score = FactoryGirl.create(:failing_score)
+      failed_review.grades.update_all(score_id: failing_score.id)
+
+      missed_assessment = FactoryGirl.create(:assessment, cohort: student.cohort)
+
+      transcript = Transcript.new(student)
+      expect(transcript.passing_assessments).to eq [passed_assessment]
+    end
+  end
+
+  describe '#attendance_score' do
+    it "calculates a score for the student's attendance record" do
+      day_one = student.cohort.start_date
+      day_two = day_one + 1.day
+      day_three = day_two + 1.day
+
+      student.cohort.update(end_date: day_three)
+
+      travel_to day_one.beginning_of_day do
+        FactoryGirl.create(:attendance_record, student: student)
+      end
+
+      travel_to day_two.beginning_of_day + 10.hours do
+        FactoryGirl.create(:attendance_record, student: student)
+      end
+
+      travel_to day_three.end_of_day do
+        transcript = Transcript.new(student)
+        expect(transcript.attendance_score).to eq 0.5
+      end
+    end
+  end
+
+
+  describe '#bottom_of_percentile_range' do
+    let(:transcript) { Transcript.new(student) }
+
+    it "rounds percentage score down to the nearest 5th percentile" do
+      allow(transcript).to receive(:attendance_score).and_return(0.96)
+      expect(transcript.bottom_of_percentile_range).to eq 95
+    end
+  end
+end


### PR DESCRIPTION
This includes a list of assessments they have met expectations on.
Methods had to be added to assessments, submissions, and reviews
in order to simplify determining if student has met expecations on
an assessment or not. This is why you'll see Review#meets_expectations?
and Submission#meets_expectations? Otherwise the logic was getting
much to hairy.
