### PR TITLE
adjust cohort attendance stats model

### DIFF
--- a/app/models/cohort_attendance_statistics.rb
+++ b/app/models/cohort_attendance_statistics.rb
@@ -6,7 +6,7 @@ class CohortAttendanceStatistics
   end
 
   def daily_presence
-    @cohort.attendance_records.group('DATE(attendance_records.created_at)').count
+    @cohort.attendance_records.group(:date).count
   end
 
   def student_attendance_data


### PR DESCRIPTION
By having the attendance record depend on its date property instead of created_at, the cohort attendance stat model needed to change, else it was showing a lot of students present on any day we created additional attendance records.