### PR TITLE
remove unnecessary method

### DIFF
--- a/app/models/attendance_record_amendment.rb
+++ b/app/models/attendance_record_amendment.rb
@@ -35,8 +35,4 @@ private
   def attendance_record
     @attendance_record ||= AttendanceRecord.find_or_initialize_by(student_id: student_id, date: date)
   end
-
-  def destroy_attendance_record
-    attendance_record.try(:destroy)
-  end
 end


### PR DESCRIPTION
When this was first written, the hope was to have separate methods for each of the three possible outcomes (creating a new attendance record, updating an existing one with the right properties, or destroying an existing one). destroy_attendance_record was the first method built with this in mind, but it's something that I soon moved away from. However, it was mistakenly left in. This commit removes that method.