### PR TITLE
Delete bcc on mailers

### DIFF
--- a/app/models/billing_tasks.rb
+++ b/app/models/billing_tasks.rb
@@ -27,9 +27,8 @@ module BillingTasks
       self.billable_in_three_days.each do |student|
         Mailgun::Client.new(ENV['MAILGUN_API_KEY']).send_message(
           "epicodus.com",
-          { :from => "michael@epicodus.com",
+          { :from => ENV['FROM_EMAIL_PAYMENT'],
             :to => student.email,
-            :bcc => "michael@epicodus.com",
             :subject => "Upcoming Epicodus tuition payment",
             :text => "Hi #{student.name}. This is just a reminder that your next Epicodus tuition payment will be withdrawn from your bank account in 3 days. If you need anything, reply to this email. Thanks!" }
         )

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -39,7 +39,6 @@ private
       "epicodus.com",
       { :from => ENV['FROM_EMAIL_PAYMENT'],
         :to => student.email,
-        :bcc => "michael@epicodus.com",
         :subject => "Epicodus tuition payment receipt",
         :text => "Hi #{student.name}. This is to confirm your payment of #{number_to_currency(total_amount / 100.00)} for Epicodus tuition. If you have any questions, reply to this email. Thanks!" }
     )
@@ -50,7 +49,6 @@ private
       "epicodus.com",
       { :from => ENV['FROM_EMAIL_PAYMENT'],
         :to => student.email,
-        :bcc => "michael@epicodus.com",
         :subject => "Epicodus payment failure notice",
         :text => "Hi #{student.name}. This is to notify you that a recent payment you made for Epicodus tuition has failed. Please reply to this email so we can sort it out together. Thanks!" }
     )

--- a/spec/models/billing_tasks_spec.rb
+++ b/spec/models/billing_tasks_spec.rb
@@ -142,9 +142,8 @@ describe BillingTasks do
 
       expect(mailgun_client).to have_received(:send_message).with(
         "epicodus.com",
-        { :from => "michael@epicodus.com",
+        { :from => ENV['FROM_EMAIL_PAYMENT'],
           :to => student.email,
-          :bcc => "michael@epicodus.com",
           :subject => "Upcoming Epicodus tuition payment",
           :text => "Hi #{student.name}. This is just a reminder that your next Epicodus tuition payment will be withdrawn from your bank account in 3 days. If you need anything, reply to this email. Thanks!" }
       )

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -100,7 +100,6 @@ describe Payment do
         "epicodus.com",
         { :from => ENV['FROM_EMAIL_PAYMENT'],
           :to => student.email,
-          :bcc => "michael@epicodus.com",
           :subject => "Epicodus tuition payment receipt",
           :text => "Hi #{student.name}. This is to confirm your payment of $618.21 for Epicodus tuition. If you have any questions, reply to this email. Thanks!" }
       )
@@ -121,7 +120,6 @@ describe Payment do
         "epicodus.com",
         { :from => ENV['FROM_EMAIL_PAYMENT'],
           :to => student.email,
-          :bcc => "michael@epicodus.com",
           :subject => "Epicodus payment failure notice",
           :text => "Hi #{student.name}. This is to notify you that a recent payment you made for Epicodus tuition has failed. Please reply to this email so we can sort it out together. Thanks!" }
       )


### PR DESCRIPTION
Found a sneaky "from" in billing_tasks, so changed that over to use ENV variables, and also removed all bcc lines from the mailers.