### PR TITLE
Add env var to bcc on mailers

### DIFF
--- a/app/models/billing_tasks.rb
+++ b/app/models/billing_tasks.rb
@@ -29,6 +29,7 @@ module BillingTasks
           "epicodus.com",
           { :from => ENV['FROM_EMAIL_PAYMENT'],
             :to => student.email,
+            :bcc => ENV['FROM_EMAIL_PAYMENT'],
             :subject => "Upcoming Epicodus tuition payment",
             :text => "Hi #{student.name}. This is just a reminder that your next Epicodus tuition payment will be withdrawn from your bank account in 3 days. If you need anything, reply to this email. Thanks!" }
         )

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -39,6 +39,7 @@ private
       "epicodus.com",
       { :from => ENV['FROM_EMAIL_PAYMENT'],
         :to => student.email,
+        :bcc => ENV['FROM_EMAIL_PAYMENT'],
         :subject => "Epicodus tuition payment receipt",
         :text => "Hi #{student.name}. This is to confirm your payment of #{number_to_currency(total_amount / 100.00)} for Epicodus tuition. If you have any questions, reply to this email. Thanks!" }
     )
@@ -49,6 +50,7 @@ private
       "epicodus.com",
       { :from => ENV['FROM_EMAIL_PAYMENT'],
         :to => student.email,
+        :bcc => ENV['FROM_EMAIL_PAYMENT'],
         :subject => "Epicodus payment failure notice",
         :text => "Hi #{student.name}. This is to notify you that a recent payment you made for Epicodus tuition has failed. Please reply to this email so we can sort it out together. Thanks!" }
     )

--- a/spec/models/billing_tasks_spec.rb
+++ b/spec/models/billing_tasks_spec.rb
@@ -144,6 +144,7 @@ describe BillingTasks do
         "epicodus.com",
         { :from => ENV['FROM_EMAIL_PAYMENT'],
           :to => student.email,
+          :bcc => ENV['FROM_EMAIL_PAYMENT'],
           :subject => "Upcoming Epicodus tuition payment",
           :text => "Hi #{student.name}. This is just a reminder that your next Epicodus tuition payment will be withdrawn from your bank account in 3 days. If you need anything, reply to this email. Thanks!" }
       )

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -100,6 +100,7 @@ describe Payment do
         "epicodus.com",
         { :from => ENV['FROM_EMAIL_PAYMENT'],
           :to => student.email,
+          :bcc => ENV['FROM_EMAIL_PAYMENT'],
           :subject => "Epicodus tuition payment receipt",
           :text => "Hi #{student.name}. This is to confirm your payment of $618.21 for Epicodus tuition. If you have any questions, reply to this email. Thanks!" }
       )
@@ -120,6 +121,7 @@ describe Payment do
         "epicodus.com",
         { :from => ENV['FROM_EMAIL_PAYMENT'],
           :to => student.email,
+          :bcc => ENV['FROM_EMAIL_PAYMENT'],
           :subject => "Epicodus payment failure notice",
           :text => "Hi #{student.name}. This is to notify you that a recent payment you made for Epicodus tuition has failed. Please reply to this email so we can sort it out together. Thanks!" }
       )


### PR DESCRIPTION
I am no longer receiving a receipt confirmation, so I have added the bcc back into the mailer field for billing and payment mailers.