### PR TITLE
Attendance signin

### DIFF
--- a/app/assets/stylesheets/attendance.css.scss
+++ b/app/assets/stylesheets/attendance.css.scss
@@ -14,3 +14,29 @@
 #student-nav li {
   cursor: pointer;
 }
+
+.btn-epicodus { 
+  color: #FFFFFF; 
+  background-color: #00B3B4; 
+  border-color: #04CCCC; 
+ 
+  &:hover, 
+  &:focus, 
+  &:active, 
+  &.active, 
+  .open .dropdown-toggle.btn-epicodus { 
+    color: #FFFFFF; 
+    background-color: #00B3B4; 
+    border-color: #04CCCC; 
+  } 
+   
+  &:active, 
+  &.active, 
+  .open .dropdown-toggle.btn-epicodus { 
+    background-image: none; 
+  } 
+}
+
+#attendance-signin-label {
+  margin-bottom: 1em;
+} 

--- a/app/controllers/attendance_sign_in_controller.rb
+++ b/app/controllers/attendance_sign_in_controller.rb
@@ -1,0 +1,62 @@
+class AttendanceSignInController < ApplicationController
+
+  def create
+    if is_weekday? && IpLocation.is_local?(request.env['HTTP_CF_CONNECTING_IP'] || request.remote_ip)
+      if params[:email2] == ""
+        sign_in_solo_student
+      else
+        sign_in_pair
+      end
+    else
+      fail('Attendance sign in unavailable.')
+    end
+  end
+
+private
+
+  def sign_in_solo_student
+    student = User.find_by(email: params[:email1])
+    if valid_credentials(student, params[:password1])
+      record = AttendanceRecord.find_or_initialize_by(student: student, date: Time.zone.now.to_date)
+      record.station = params[:station]
+      record.save
+      redirect_to welcome_path, notice: "Welcome #{student.name}. Your attendance record has been created."
+    else
+      fail('Invalid email or password.')
+    end
+  end
+
+  def sign_in_pair
+    student1 = User.find_by(email: params[:email1])
+    student2 = User.find_by(email: params[:email2])
+    if student1 != student2 && valid_credentials(student1, params[:password1]) && valid_credentials(student2, params[:password2])
+      record1 = AttendanceRecord.find_or_initialize_by(student: student1, date: Time.zone.now.to_date)
+      record2 = AttendanceRecord.find_or_initialize_by(student: student2, date: Time.zone.now.to_date)
+      if record1 && record2 && record1.student && record2.student # This should always be the case, but is extra check.
+        record1.station = params[:station]
+        record2.station = params[:station]
+        record1.pair_id = student2.id
+        record2.pair_id = student1.id
+        if record1.save && record2.save
+          redirect_to welcome_path, notice: "Welcome #{student1.name} and #{student2.name}. Your attendance records have been created."
+        else
+          fail('There was a problem saving attendance records. Please notify a teacher.')
+        end
+      else
+        fail('There was a problem initializing attendance records. Please notify a teacher.')
+      end
+    else
+      fail('Invalid login credentials.')
+    end
+
+  end
+
+  def valid_credentials(user, pw)
+    user.try(:valid_password?, pw)
+  end
+
+  def fail(message)
+    redirect_to sign_in_path, alert: message
+  end
+
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
   def hide_navbar
     paths = [new_code_of_conduct_path, new_refund_policy_path, new_enrollment_agreement_path,
              certificate_path, transcript_path, welcome_path, user_session_path,
-             new_user_password_path, root_path, new_company_registration_path, sign_out_path]
+             new_user_password_path, root_path, new_company_registration_path, sign_out_path, sign_in_path]
     true if paths.map { |path| current_page?(path) }.include?(true)
   end
 

--- a/app/views/attendance_sign_in/new.html.erb
+++ b/app/views/attendance_sign_in/new.html.erb
@@ -1,0 +1,39 @@
+<% if is_weekday? && IpLocation.is_local_computer?(request.env['HTTP_CF_CONNECTING_IP'] || request.remote_ip) %>
+<h2 id="attendance-signin-label" class="text-center">Attendance sign in</h2>
+  <div class="row">
+    <div class="col-md-4 col-md-offset-4">
+      <%= form_tag sign_in_path do %>
+        <%= hidden_field_tag :signing_in, value: true %>
+        <div class="well">
+          <div class="form-group">
+            <%= label_tag :email1, "Email (first student)" %>
+            <%= text_field_tag 'email1', nil, autofocus: true, class: "form-control" %>
+          </div>
+          <div class="form-group">
+            <%= label_tag :password1, "Password (first student)" %>
+            <%= password_field_tag 'password1', nil, autocomplete: "off", class: "form-control" %>
+          </div>
+        </div>
+        <div class="well">
+          <div class="form-group">
+            <%= label_tag :email2, "Email (second student)" %>
+            <%= text_field_tag 'email2', nil, class: "form-control" %>
+          </div>
+          <div class="form-group">
+            <%= label_tag :password2, "Password (second student)" %>
+            <%= password_field_tag 'password2', nil, autocomplete: "off", class: "form-control" %>
+          </div>
+        </div>
+        <div class="well">
+          <div class="form-group">
+            <%= label_tag :station %>
+            <%= text_field_tag :station, nil, class: "form-control" %>
+          </div>
+        </div>
+        <%= submit_tag 'Attendance sign in', class: "btn btn-epicodus btn-block" %>
+      <% end %>
+    </div>
+  </div>
+<% else %>
+  <h2 id="attendance-signin-label" class="text-center">Attendance sign in unavailable.</h2>
+<% end %>

--- a/app/views/attendance_sign_in/new.html.erb
+++ b/app/views/attendance_sign_in/new.html.erb
@@ -1,39 +1,41 @@
-<% if is_weekday? && IpLocation.is_local_computer?(request.env['HTTP_CF_CONNECTING_IP'] || request.remote_ip) %>
-<h2 id="attendance-signin-label" class="text-center">Attendance sign in</h2>
-  <div class="row">
-    <div class="col-md-4 col-md-offset-4">
-      <%= form_tag sign_in_path do %>
-        <%= hidden_field_tag :signing_in, value: true %>
-        <div class="well">
-          <div class="form-group">
-            <%= label_tag :email1, "Email (first student)" %>
-            <%= text_field_tag 'email1', nil, autofocus: true, class: "form-control" %>
+<div class="panel">
+  <% if is_weekday? && IpLocation.is_local_computer?(request.env['HTTP_CF_CONNECTING_IP'] || request.remote_ip) %>
+    <h2 id="attendance-signin-label" class="text-center">Attendance sign in</h2>
+    <div class="row">
+      <div class="col-md-4 col-md-offset-4">
+        <%= form_tag sign_in_path do %>
+          <%= hidden_field_tag :signing_in, value: true %>
+          <div class="well">
+            <div class="form-group">
+              <%= label_tag :email1, "Email (first student)" %>
+              <%= text_field_tag 'email1', nil, autofocus: true, class: "form-control" %>
+            </div>
+            <div class="form-group">
+              <%= label_tag :password1, "Password (first student)" %>
+              <%= password_field_tag 'password1', nil, autocomplete: "off", class: "form-control" %>
+            </div>
           </div>
-          <div class="form-group">
-            <%= label_tag :password1, "Password (first student)" %>
-            <%= password_field_tag 'password1', nil, autocomplete: "off", class: "form-control" %>
+          <div class="well">
+            <div class="form-group">
+              <%= label_tag :email2, "Email (second student)" %>
+              <%= text_field_tag 'email2', nil, class: "form-control" %>
+            </div>
+            <div class="form-group">
+              <%= label_tag :password2, "Password (second student)" %>
+              <%= password_field_tag 'password2', nil, autocomplete: "off", class: "form-control" %>
+            </div>
           </div>
-        </div>
-        <div class="well">
-          <div class="form-group">
-            <%= label_tag :email2, "Email (second student)" %>
-            <%= text_field_tag 'email2', nil, class: "form-control" %>
+          <div class="well">
+            <div class="form-group">
+              <%= label_tag :station %>
+              <%= text_field_tag :station, nil, class: "form-control" %>
+            </div>
           </div>
-          <div class="form-group">
-            <%= label_tag :password2, "Password (second student)" %>
-            <%= password_field_tag 'password2', nil, autocomplete: "off", class: "form-control" %>
-          </div>
-        </div>
-        <div class="well">
-          <div class="form-group">
-            <%= label_tag :station %>
-            <%= text_field_tag :station, nil, class: "form-control" %>
-          </div>
-        </div>
-        <%= submit_tag 'Attendance sign in', class: "btn btn-epicodus btn-block" %>
-      <% end %>
+          <%= submit_tag 'Attendance sign in', class: "btn btn-epicodus btn-block" %>
+        <% end %>
+      </div>
     </div>
-  </div>
-<% else %>
-  <h2 id="attendance-signin-label" class="text-center">Attendance sign in unavailable.</h2>
-<% end %>
+  <% else %>
+    <h2 id="attendance-signin-label" class="text-center">Attendance sign in unavailable.</h2>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_scope :user do
     root 'users/sessions#new'
   end
+  get 'sign_in', to: 'attendance_sign_in#new'
   get 'sign_out', to: 'attendance_sign_out#new'
   get 'welcome', to: 'static_pages#show'
   get 'auth/:provider/callback', to: 'omniauth_callbacks#create'
@@ -60,6 +61,7 @@ Rails.application.routes.draw do
   resource :code_review_copy, only: [:create]
   resource :random_pairs, only: [:show]
   resources :enrollments, only: [:create, :destroy]
+  resource :sign_in, controller: 'attendance_sign_in', only: [:create]
   resource :sign_out, controller: 'attendance_sign_out', only: [:create]
   resource :course_internships, only: [:create, :destroy]
   resource :interview_assignments, only: [:destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   end
   get 'sign_in', to: 'attendance_sign_in#new'
   get 'sign_out', to: 'attendance_sign_out#new'
+  get '/sign-in' => redirect('/sign_in')
+  get '/signin' => redirect('/sign_in')
+  get '/sign-out' => redirect('/sign_out')
+  get '/signout' => redirect('/sign_out')
   get 'welcome', to: 'static_pages#show'
   get 'auth/:provider/callback', to: 'omniauth_callbacks#create'
 

--- a/spec/features/attendance_sign_in_pages_spec.rb
+++ b/spec/features/attendance_sign_in_pages_spec.rb
@@ -1,0 +1,199 @@
+feature "Student does attendance sign in" do
+  let(:student) { FactoryGirl.create(:user_with_all_documents_signed, password: 'password1', password_confirmation: 'password1') }
+  let(:pair) { FactoryGirl.create(:user_with_all_documents_signed, password: 'password2', password_confirmation: 'password2') }
+
+  def attendance_sign_in_solo
+    visit sign_in_path
+    fill_in 'email1', with: student.email
+    fill_in 'password1', with: student.password
+    click_button 'Attendance sign in'
+  end
+
+  def attendance_sign_in_pair
+    visit sign_in_path
+    fill_in 'email1', with: student.email
+    fill_in 'password1', with: student.password
+    fill_in 'email2', with: pair.email
+    fill_in 'password2', with: pair.password
+    click_button 'Attendance sign in'
+  end
+
+  context "not at school" do
+    it "does not show attendance sign in page" do
+      allow(IpLocation).to receive(:is_local?).and_return(false)
+      allow(IpLocation).to receive(:is_local_computer?).and_return(false)
+      visit sign_in_path
+      expect(page).to have_content "Attendance sign in unavailable."
+    end
+  end
+
+  context "not a weekday" do
+    it "does not show attendance sign in page" do
+      allow_any_instance_of(ApplicationController).to receive(:is_weekday?).and_return(false)
+      visit sign_in_path
+      expect(page).to have_content "Attendance sign in unavailable."
+    end
+  end
+
+  context "a weekday at school" do
+    before do
+      allow(IpLocation).to receive(:is_local?).and_return(true)
+      allow(IpLocation).to receive(:is_local_computer?).and_return(true)
+      allow_any_instance_of(ApplicationController).to receive(:is_weekday?).and_return(true)
+    end
+
+    it "shows attendance sign in page" do
+      visit sign_in_path
+      expect(page).to have_content "first student"
+    end
+
+    context "when soloing" do
+      context "incorrect login credentials" do
+        it "gives an error for an incorrect email" do
+          visit sign_in_path
+          fill_in 'email1', with: 'wrong'
+          fill_in 'password1', with: student.password
+          click_button 'Attendance sign in'
+          expect(page).to have_content 'Invalid email or password.'
+        end
+
+        it "gives an error for an incorrect password" do
+          visit sign_in_path
+          fill_in 'email1', with: student.email
+          fill_in 'password1', with: 'wrong'
+          click_button 'Attendance sign in'
+          expect(page).to have_content 'Invalid email or password.'
+        end
+      end
+
+      it "takes them to the welcome page" do
+        attendance_sign_in_solo
+        expect(current_path).to eq welcome_path
+        expect(page).to have_content 'Your attendance record has been created.'
+      end
+
+      it "creates an attendance record for them" do
+        thursday = Time.zone.now.to_date.beginning_of_week + 3.days
+        travel_to thursday do
+          expect { attendance_sign_in_solo }.to change { student.attendance_records.count }.by 1
+        end
+      end
+
+      it 'does not update the attendance record on subsequent solo sign ins during the day' do
+        travel_to student.course.start_date + 8.hours do
+          attendance_sign_in_solo
+        end
+        attendance_record = AttendanceRecord.find_by(student: student)
+        travel_to student.course.start_date + 12.hours do
+          attendance_sign_in_solo
+          expect(attendance_record.tardy).to be false
+          expect(AttendanceRecord.count).to equal 1
+        end
+      end
+    end
+
+    context "when pairing" do
+      context "incorrect login credentials" do
+        it "gives an error for an incorrect email1" do
+          visit sign_in_path
+          fill_in 'email1', with: 'wrong'
+          fill_in 'password1', with: student.password
+          fill_in 'email2', with: pair.email
+          fill_in 'password2', with: pair.password
+          click_button 'Attendance sign in'
+          expect(page).to have_content 'Invalid login credentials.'
+        end
+
+        it "gives an error for an incorrect email2" do
+          visit sign_in_path
+          fill_in 'email1', with: student.email
+          fill_in 'password1', with: student.password
+          fill_in 'email2', with: 'wrong'
+          fill_in 'password2', with: pair.password
+          click_button 'Attendance sign in'
+          expect(page).to have_content 'Invalid login credentials.'
+        end
+
+        it "gives an error for an incorrect password1" do
+          visit sign_in_path
+          fill_in 'email1', with: student.email
+          fill_in 'password1', with: 'wrong'
+          fill_in 'email2', with: pair.email
+          fill_in 'password2', with: pair.password
+          click_button 'Attendance sign in'
+          expect(page).to have_content 'Invalid login credentials.'
+        end
+
+        it "gives an error for an incorrect password1" do
+          visit sign_in_path
+          fill_in 'email1', with: student.email
+          fill_in 'password1', with: student.password
+          fill_in 'email2', with: pair.email
+          fill_in 'password2', with: 'wrong'
+          click_button 'Attendance sign in'
+          expect(page).to have_content 'Invalid login credentials.'
+        end
+      end
+
+      it "takes them to the welcome page" do
+        attendance_sign_in_pair
+        expect(current_path).to eq welcome_path
+        expect(page).to have_content 'Your attendance records have been created.'
+      end
+
+      it "creates attendance records for both students" do
+        thursday = Time.zone.now.to_date.beginning_of_week + 3.days
+        travel_to thursday do
+          attendance_sign_in_pair
+          expect(AttendanceRecord.count).to equal 2
+        end
+      end
+
+      it 'creates attendance records if one student has already signed in for the day' do
+        FactoryGirl.create(:attendance_record, student: student)
+        expect { attendance_sign_in_pair }.to change { AttendanceRecord.count }.by 1
+      end
+
+      it 'updates the pair id if one student has already signed in for the day' do
+        FactoryGirl.create(:attendance_record, student: student)
+        expect { attendance_sign_in_pair }.to change { AttendanceRecord.first.pair_id }.from(nil).to(pair.id)
+      end
+
+      it 'does not update the attendance record when signing as pairs, then solo during same day' do
+        travel_to student.course.start_date + 8.hours do
+          attendance_sign_in_pair
+        end
+        attendance_record = AttendanceRecord.find_by(student: pair)
+        travel_to student.course.start_date + 12.hours do
+          sign_in_as(pair)
+          expect(attendance_record.tardy).to be false
+        end
+      end
+
+      it 'does not update the attendance record when signing as solo, then pair during same day' do
+        travel_to student.course.start_date + 8.hours do
+          attendance_sign_in_solo
+        end
+        attendance_record = AttendanceRecord.find_by(student: student)
+        travel_to student.course.start_date + 12.hours do
+          attendance_sign_in_pair
+          expect(attendance_record.tardy).to be false
+        end
+      end
+
+      it 'does not update the attendance record when signing in solo, then as pairs, then solo again during same day' do
+        travel_to student.course.start_date + 8.hours do
+          attendance_sign_in_solo
+        end
+        travel_to student.course.start_date + 10.hours do
+          attendance_sign_in_pair
+        end
+        attendance_record = AttendanceRecord.find_by(student: student)
+        travel_to student.course.start_date + 14.hours do
+          attendance_sign_in_solo
+          expect(attendance_record.tardy).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should complete a separate attendance sign in page at the /sign_in URL, not connected with Epicenter sign in. I'm making a separate pull request for removing the sign_in functionality from epicenter, in case we want to leave it in both places for a bit. (Also we would need to re-set the homepage on the Epicodus computers to use the new /sign_in page.)