### PR TITLE
minor attendance record signout fix

### DIFF
--- a/app/controllers/attendance_sign_out_controller.rb
+++ b/app/controllers/attendance_sign_out_controller.rb
@@ -16,8 +16,8 @@ class AttendanceSignOutController < ApplicationController
 private
 
   def redirect_if_not_authorized_to_sign_out
-    if !is_weekday? && !IpLocation.is_local?(request.env['HTTP_CF_CONNECTING_IP'] || request.remote_ip)
-      redirect_to root_path
+    if !is_weekday? || !IpLocation.is_local?(request.env['HTTP_CF_CONNECTING_IP'] || request.remote_ip)
+      redirect_to root_path, alert: 'Unable to update attendance record.'
     end
   end
 


### PR DESCRIPTION
Two really minor changes to attendance sign out controller:

1. Change && to || since we want it to fail if it's not a weekday OR if the IP is not local
2. Add alert message when it redirects so that it is clear to the student that it didn't work.