### PR TITLE
allow students to export code review submissions list to file

### DIFF
--- a/app/controllers/code_review_export_controller.rb
+++ b/app/controllers/code_review_export_controller.rb
@@ -1,0 +1,10 @@
+class CodeReviewExportController < ApplicationController
+
+  def show
+    code_review = CodeReview.find(params[:code_review_id])
+    filename = Rails.root.join('tmp','students.txt')
+    code_review.export_submissions(filename)
+    send_file(filename)    
+  end
+
+end

--- a/app/models/code_review.rb
+++ b/app/models/code_review.rb
@@ -51,6 +51,15 @@ class CodeReview < ActiveRecord::Base
     end
   end
 
+  def export_submissions(filename)
+    submissions = self.submissions.needing_review.includes(:student)
+    File.open(filename, 'w') do |file|
+      submissions.each do |submission|
+        file.puts submission.student.name.parameterize + " " + submission.link
+      end
+    end
+  end
+
 private
 
   def check_for_submissions

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -1,5 +1,8 @@
 <h1>Submissions for <%= @code_review.title %></h1>
-<h3><%= @code_review.course.description %></h3>
+<h3>
+  <%= @code_review.course.description %>
+  <%= link_to 'EXPORT', code_review_export_path(@code_review), id: "export-btn", :class => "btn btn-xs btn-default" %>
+</h3>
 
 <div class="panel panel-default">
   <div class="panel-body">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   resources :companies, only: [:show]
 
   resources :code_reviews, only: [:destroy] do
+    resource :export, only: [:show], to: 'code_review_export#show'
     resources :submissions, only: [:index, :create, :update]
     collection do
       patch :update_multiple, :path => ''

--- a/spec/features/code_reviews_pages_spec.rb
+++ b/spec/features/code_reviews_pages_spec.rb
@@ -334,3 +334,18 @@ feature 'deleting a code review' do
     expect(page).to have_content "Cannot delete a code review with existing submissions."
   end
 end
+
+feature 'exporting code review details to a file' do
+  let(:admin) { FactoryGirl.create(:admin) }
+  let(:code_review) { FactoryGirl.create(:code_review) }
+
+  before { login_as(admin, scope: :admin) }
+
+  scenario 'exports info on all submissions for a code review' do
+    FactoryGirl.create(:submission, code_review: code_review)
+    visit code_review_submissions_path(code_review)
+    click_link 'export-btn'
+    filename = Rails.root.join('tmp','students.txt')
+    expect(filename).to exist
+  end
+end

--- a/spec/models/code_review_spec.rb
+++ b/spec/models/code_review_spec.rb
@@ -125,4 +125,15 @@ describe CodeReview do
       expect(code_review.status(student)).to eq 'Pending'
     end
   end
+
+  describe '#export_submissions' do
+    it 'exports submissions info for code review to students.txt file' do
+      code_review = FactoryGirl.create(:code_review)
+      submission = FactoryGirl.create(:submission, code_review: code_review)
+      filename = Rails.root.join('tmp','students.txt')
+      code_review.export_submissions(filename)
+      expect(File.read(filename)).to include submission.link
+    end
+  end
+
 end


### PR DESCRIPTION
Resubmitting PR for export of code review submissions list to students.txt file. I've rebased and squashed extraneous commits. Let me know if there's anything else I can do to clean this up.