### PR TITLE
pull course & name from Close on student invite rather than entering manually

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -4,8 +4,16 @@ class InvitationsController < Devise::InvitationsController
     if params[:student_id]
       resend_invitation
     else
-      super
-      set_flash_for_student
+      email = params[:student][:email]
+      response = Student.pull_info_from_crm(email)
+      if response[:name] && response[:course_id]
+        params[:student][:name] = response[:name]
+        params[:student][:course_id] = response[:course_id]
+        super
+        set_flash_for_student
+      else
+        redirect_to new_student_invitation_path, alert: "Invalid email / name / course for #{email} in Close"
+      end
     end
   end
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -280,4 +280,18 @@ private
       errors.add(:primary_payment_method, 'must belong to you.')
     end
   end
+
+  def self.pull_info_from_crm(email)
+    close_io_client = Closeio::Client.new(ENV['CLOSE_IO_API_KEY'], false)
+    lead = close_io_client.list_leads('email:' + email)
+    if lead.total_results == 1
+      name = lead.data.first.contacts.first.name
+      course = Course.find_by(description: lead.data.first.custom.Class)
+      if name && course
+        return {name: name, course_id: course.id}
+      end
+    end
+    return {}
+  end
+
 end

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -15,28 +15,20 @@
         <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post } do |f| %>
           <%= devise_error_messages! %>
 
-          <% if resource.is_a?(Student) %>
+          <% resource.class.invite_key_fields.each do |field| -%>
             <div class="form-group">
-              <%= f.label :course_id, class: "control-label" %>
-              <%= f.select :course_id, Course.current_and_future_courses.reverse.collect {|c| [ c.teacher_and_description, c.id ] }, {}, { class: "form-control" } %>
+              <%= f.label field, class: "control-label" %>
+              <%= f.text_field field, class: "form-control" %>
             </div>
-          <% end %>
-
-          <div class="form-group">
-            <%= f.label :name, class: "control-label" %>
-            <%= f.text_field :name, class: "form-control" %>
-          </div>
-
-        <% resource.class.invite_key_fields.each do |field| -%>
-          <div class="form-group">
-            <%= f.label field, class: "control-label" %>
-            <%= f.text_field field, class: "form-control" %>
-          </div>
-        <% end -%>
+          <% end -%>
 
           <% if resource.is_a?(Student) %>
             <%= f.submit 'Invite student', class: "btn btn-info" %>
-          <% else %>
+          <% elsif resource.is_a?(Admin) %>
+            <div class="form-group">
+              <%= f.label :name, class: "control-label" %>
+              <%= f.text_field :name, class: "form-control" %>
+            </div>
             <%= f.submit 'Invite admin', class: "btn btn-info" %>
           <% end %>
         <% end %>

--- a/spec/cassettes/Inviting_new_users/admin_fails_to_send_invitation_to_a_student.yml
+++ b/spec/cassettes/Inviting_new_users/admin_fails_to_send_invitation_to_a_student.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://app.close.io/api/v1/lead/?query=email:bad_email
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Basic ZDRjOTYwOTdjODY4YjU2NzIwMzU0NmU3MjIwZWNkMjM0MWYwMDhmMjk0M2FjZWRkYzUyMjMyMmQ6
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Dec 2016 20:16:52 GMT
+      Set-Cookie:
+      - session=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '51'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"has_more": false, "total_results": 0, "data": []}'
+    http_version: 
+  recorded_at: Thu, 01 Dec 2016 20:16:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Inviting_new_users/admin_resends_invitation_to_a_student.yml
+++ b/spec/cassettes/Inviting_new_users/admin_resends_invitation_to_a_student.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://app.close.io/api/v1/lead/?query=email:example@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Basic ZDRjOTYwOTdjODY4YjU2NzIwMzU0NmU3MjIwZWNkMjM0MWYwMDhmMjk0M2FjZWRkYzUyMjMyMmQ6
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Dec 2016 20:20:01 GMT
+      Set-Cookie:
+      - session=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '881'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"has_more": false, "total_results": 1, "data": [{"tasks": [], "addresses":
+        [], "date_updated": "2016-12-01T18:09:01.637000+00:00", "created_by_name":
+        "Michael Kaiser-Nyman", "opportunities": [], "custom.lcf_sXaSO35CeYV0CSLrlxo4s1zKUCIQxAuynB7YsLlt7M8":
+        1, "id": "lead_4LhIfianLPowbWVnZgOBHQ8Flgm26Wu6YsssnTkKg26", "description":
+        "Foo", "display_name": "TEST TEST", "contacts": [{"name": "TEST TEST", "title":
+        "", "date_updated": "2016-12-01T18:09:01.630000+00:00", "phones": [], "created_by":
+        "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9", "id": "cont_FStz8S1Oe1diS12GwlUZM3kd9An7qfrPhTkQ3nyxvoH",
+        "organization_id": "orga_IRlZ0dse4odbsGRQCuEZFhRQyFgzcNzvbpIXaeg74pE", "urls":
+        [], "date_created": "2015-08-04T20:54:51.401000+00:00", "integration_links":
+        [], "emails": [{"type": "office", "email": "example@example.com"}], "updated_by":
+        "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9"}], "custom.lcf_B410rIUtklIKHiSrxnQDvocLUp9D3gpuFGxP49Vgtl8":
+        "Standard Plan - $150 then $850", "created_by": "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9",
+        "custom": {"Payment plan": "Standard Plan - $150 then $850", "Amount paid":
+        1, "Class": "2017-01 Intro"}, "updated_by_name": "Michael Kaiser-Nyman", "updated_by":
+        "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9", "status_id": "stat_IAcdBqZZTAul6vK2srakLxAyd8Kem3ALHW6MBg12ntc",
+        "html_url": "https://app.close.io/lead/lead_4LhIfianLPowbWVnZgOBHQ8Flgm26Wu6YsssnTkKg26/",
+        "organization_id": "orga_IRlZ0dse4odbsGRQCuEZFhRQyFgzcNzvbpIXaeg74pE", "integration_links":
+        [{"url": "https://epicenter.epicodus.com/students?utf8=%E2%9C%93&search=TEST%20TEST&button=",
+        "name": "Epicenter Link"}], "custom.lcf_Gm7m9WYKo5s8r8hOllbu1FHZEcHFLYjckMecIFdeg0a":
+        "2017-01 Intro", "name": "TEST TEST", "url": null, "status_label": "Enrolled",
+        "date_created": "2015-08-04T20:54:51.404000+00:00"}]}'
+    http_version: 
+  recorded_at: Thu, 01 Dec 2016 20:20:01 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Inviting_new_users/admin_sends_invitation_to_a_student.yml
+++ b/spec/cassettes/Inviting_new_users/admin_sends_invitation_to_a_student.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://app.close.io/api/v1/lead/?query=email:example@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Basic ZDRjOTYwOTdjODY4YjU2NzIwMzU0NmU3MjIwZWNkMjM0MWYwMDhmMjk0M2FjZWRkYzUyMjMyMmQ6
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Dec 2016 20:16:51 GMT
+      Set-Cookie:
+      - session=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '881'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"has_more": false, "total_results": 1, "data": [{"tasks": [], "addresses":
+        [], "date_updated": "2016-12-01T18:09:01.637000+00:00", "created_by_name":
+        "Michael Kaiser-Nyman", "opportunities": [], "custom.lcf_sXaSO35CeYV0CSLrlxo4s1zKUCIQxAuynB7YsLlt7M8":
+        1, "id": "lead_4LhIfianLPowbWVnZgOBHQ8Flgm26Wu6YsssnTkKg26", "description":
+        "Foo", "display_name": "TEST TEST", "contacts": [{"name": "TEST TEST", "title":
+        "", "date_updated": "2016-12-01T18:09:01.630000+00:00", "phones": [], "created_by":
+        "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9", "id": "cont_FStz8S1Oe1diS12GwlUZM3kd9An7qfrPhTkQ3nyxvoH",
+        "organization_id": "orga_IRlZ0dse4odbsGRQCuEZFhRQyFgzcNzvbpIXaeg74pE", "urls":
+        [], "date_created": "2015-08-04T20:54:51.401000+00:00", "integration_links":
+        [], "emails": [{"type": "office", "email": "example@example.com"}], "updated_by":
+        "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9"}], "custom.lcf_B410rIUtklIKHiSrxnQDvocLUp9D3gpuFGxP49Vgtl8":
+        "Standard Plan - $150 then $850", "created_by": "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9",
+        "custom": {"Payment plan": "Standard Plan - $150 then $850", "Amount paid":
+        1, "Class": "2017-01 Intro"}, "updated_by_name": "Michael Kaiser-Nyman", "updated_by":
+        "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9", "status_id": "stat_IAcdBqZZTAul6vK2srakLxAyd8Kem3ALHW6MBg12ntc",
+        "html_url": "https://app.close.io/lead/lead_4LhIfianLPowbWVnZgOBHQ8Flgm26Wu6YsssnTkKg26/",
+        "organization_id": "orga_IRlZ0dse4odbsGRQCuEZFhRQyFgzcNzvbpIXaeg74pE", "integration_links":
+        [{"url": "https://epicenter.epicodus.com/students?utf8=%E2%9C%93&search=TEST%20TEST&button=",
+        "name": "Epicenter Link"}], "custom.lcf_Gm7m9WYKo5s8r8hOllbu1FHZEcHFLYjckMecIFdeg0a":
+        "2017-01 Intro", "name": "TEST TEST", "url": null, "status_label": "Enrolled",
+        "date_created": "2015-08-04T20:54:51.404000+00:00"}]}'
+    http_version: 
+  recorded_at: Thu, 01 Dec 2016 20:16:51 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/Student/_pull_info_from_crm/returns_name_Epicenter_course_id_for_close_io_lead_given_email.yml
+++ b/spec/cassettes/Student/_pull_info_from_crm/returns_name_Epicenter_course_id_for_close_io_lead_given_email.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://app.close.io/api/v1/lead/?query=email:example@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Basic ZDRjOTYwOTdjODY4YjU2NzIwMzU0NmU3MjIwZWNkMjM0MWYwMDhmMjk0M2FjZWRkYzUyMjMyMmQ6
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 01 Dec 2016 20:18:08 GMT
+      Set-Cookie:
+      - session=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - Accept
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '881'
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: '{"has_more": false, "total_results": 1, "data": [{"tasks": [], "addresses":
+        [], "date_updated": "2016-12-01T18:09:01.637000+00:00", "created_by_name":
+        "Michael Kaiser-Nyman", "opportunities": [], "custom.lcf_sXaSO35CeYV0CSLrlxo4s1zKUCIQxAuynB7YsLlt7M8":
+        1, "id": "lead_4LhIfianLPowbWVnZgOBHQ8Flgm26Wu6YsssnTkKg26", "description":
+        "Foo", "display_name": "TEST TEST", "contacts": [{"name": "TEST TEST", "title":
+        "", "date_updated": "2016-12-01T18:09:01.630000+00:00", "phones": [], "created_by":
+        "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9", "id": "cont_FStz8S1Oe1diS12GwlUZM3kd9An7qfrPhTkQ3nyxvoH",
+        "organization_id": "orga_IRlZ0dse4odbsGRQCuEZFhRQyFgzcNzvbpIXaeg74pE", "urls":
+        [], "date_created": "2015-08-04T20:54:51.401000+00:00", "integration_links":
+        [], "emails": [{"type": "office", "email": "example@example.com"}], "updated_by":
+        "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9"}], "custom.lcf_B410rIUtklIKHiSrxnQDvocLUp9D3gpuFGxP49Vgtl8":
+        "Standard Plan - $150 then $850", "created_by": "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9",
+        "custom": {"Payment plan": "Standard Plan - $150 then $850", "Amount paid":
+        1, "Class": "2017-01 Intro"}, "updated_by_name": "Michael Kaiser-Nyman", "updated_by":
+        "user_ABOHi4Y53EYGaL6y4ioR2VXABSEPGSQh2xoJHnaiEP9", "status_id": "stat_IAcdBqZZTAul6vK2srakLxAyd8Kem3ALHW6MBg12ntc",
+        "html_url": "https://app.close.io/lead/lead_4LhIfianLPowbWVnZgOBHQ8Flgm26Wu6YsssnTkKg26/",
+        "organization_id": "orga_IRlZ0dse4odbsGRQCuEZFhRQyFgzcNzvbpIXaeg74pE", "integration_links":
+        [{"url": "https://epicenter.epicodus.com/students?utf8=%E2%9C%93&search=TEST%20TEST&button=",
+        "name": "Epicenter Link"}], "custom.lcf_Gm7m9WYKo5s8r8hOllbu1FHZEcHFLYjckMecIFdeg0a":
+        "2017-01 Intro", "name": "TEST TEST", "url": null, "status_label": "Enrolled",
+        "date_created": "2015-08-04T20:54:51.404000+00:00"}]}'
+    http_version: 
+  recorded_at: Thu, 01 Dec 2016 20:18:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/features/admin_pages_spec.rb
+++ b/spec/features/admin_pages_spec.rb
@@ -69,37 +69,34 @@ feature 'Changing current course' do
   end
 end
 
-feature 'Inviting new users' do
+feature 'Inviting new users', :vcr do
   let(:admin) { FactoryGirl.create(:admin) }
-  let(:course) { FactoryGirl.build(:course) }
+  let!(:course) { FactoryGirl.create(:course, description: '2017-01 Intro') }
 
   before { login_as(admin, scope: :admin) }
 
   scenario 'admin sends invitation to a student' do
     visit new_student_invitation_path
-    select course.description, from: 'student_course_id'
-    fill_in 'Email', with: 'newstudent@example.com'
+    fill_in 'Email', with: 'example@example.com'
     click_on 'Invite student'
-    expect(page).to have_content "An invitation email has been sent to newstudent@example.com to join #{course.description}. Wrong course?"
+    expect(page).to have_content "An invitation email has been sent to example@example.com to join 2017-01 Intro. Wrong course?"
   end
 
   scenario 'admin fails to send invitation to a student' do
     visit new_student_invitation_path
-    select course.description, from: 'student_course_id'
     fill_in 'Email', with: 'bad_email'
     click_on 'Invite student'
-    expect(page).to have_content "Email is invalid"
+    expect(page).to have_content "Invalid email / name / course"
   end
 
   scenario 'admin resends invitation to a student' do
     visit new_student_invitation_path
-    select course.description, from: 'student_course_id'
-    fill_in 'Email', with: 'newstudent@example.com'
+    fill_in 'Email', with: 'example@example.com'
     click_on 'Invite student'
-    student = Student.find_by(email: 'newstudent@example.com')
+    student = Student.find_by(email: 'example@example.com')
     visit student_courses_path(student)
     click_on 'Resend invitation'
-    expect(page).to have_content "A new invitation email has been sent to newstudent@example.com"
+    expect(page).to have_content "A new invitation email has been sent to example@example.com"
   end
 
   scenario 'admin sends invitation to an admin' do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -755,4 +755,11 @@ describe Student do
       it { is_expected.to have_abilities(:read, Transcript) }
     end
   end
+
+  describe '.pull_info_from_crm', :vcr do
+    it 'returns name & Epicenter course id for close_io lead given email' do
+      course = FactoryGirl.create(:course, description: "2017-01 Intro")
+      expect(Student.pull_info_from_crm("example@example.com")).to eq({name: "TEST TEST", course_id: course.id})
+    end
+  end
 end


### PR DESCRIPTION
Simplify invite process by pulling student name & course description from Close and creating based on that rather than requiring manual and mistake-prone selection of course in Epicenter.