### PR TITLE
add interview location & internship on-site/remote to internship

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,8 +11,8 @@ protected
     devise_parameter_sanitizer.permit(:sign_up) do |u|
       u.permit(:name, :email, :password, :password_confirmation,
                internships_attributes: [:name, :description, :website, :address,
-                                        :ideal_intern, :clearance_required,
-                                        :clearance_description, :number_of_students,
+                                        :interview_location, :ideal_intern, :clearance_required,
+                                        :clearance_description, :number_of_students, :remote,
                                         track_ids: [], course_ids: []])
     end
     devise_parameter_sanitizer.permit(:invite) do |u|

--- a/app/controllers/internships_controller.rb
+++ b/app/controllers/internships_controller.rb
@@ -33,9 +33,9 @@ class InternshipsController < ApplicationController
 private
 
   def internship_params
-    params.require(:internship).permit(:name, :website, :address, :description,
+    params.require(:internship).permit(:name, :website, :address, :interview_location, :description,
                                        :ideal_intern, :clearance_required,
-                                       :clearance_description, :number_of_students,
+                                       :clearance_description, :number_of_students, :remote, 
                                        track_ids: [], course_ids: [])
   end
 end

--- a/app/views/devise/registrations/_internships_fields.html.erb
+++ b/app/views/devise/registrations/_internships_fields.html.erb
@@ -44,6 +44,23 @@
     </div>
   </div>
 
+  <div class='form-group'>
+    <%= ff.label :remote, "* Will the students be working on-site or remotely?" %>
+    <div class="radio">
+      <%= ff.label :remote do %>
+        <%= ff.radio_button :remote, false, checked: true %> on-site
+      <% end %>
+      </label>
+    </div>
+
+    <div class="radio">
+      <%= ff.label :remote do %>
+        <%= ff.radio_button :remote, true %> remote
+      <% end %>
+      </label>
+    </div>
+  </div>
+
   <div class="form-group" id="course-multiselect">
     <%= ff.label :track_ids, "* Which classes are you willing to interview students from? (all include JavaScript)" %>
     <br>
@@ -58,6 +75,11 @@
   <div class='form-group'>
     <%= ff.label :address %>
     <%= ff.text_field :address, class: 'form-control' %>
+  </div>
+
+  <div class='form-group'>
+    <%= ff.label :interview_location, "interview location (if different)" %>
+    <%= ff.text_field :interview_location, class: 'form-control' %>
   </div>
 
   <div class='form-group'>

--- a/app/views/internships/_form.html.erb
+++ b/app/views/internships/_form.html.erb
@@ -50,6 +50,23 @@
         </div>
       </div>
 
+      <div class='form-group'>
+        <%= f.label :remote, "* Will the students be working on-site or remotely?" %>
+        <div class="radio">
+          <%= f.label :remote do %>
+            <%= f.radio_button :remote, false, required: true %> on-site
+          <% end %>
+          </label>
+        </div>
+
+        <div class="radio">
+          <%= f.label :remote do %>
+            <%= f.radio_button :remote, true %> remote
+          <% end %>
+          </label>
+        </div>
+      </div>
+
       <div class="form-group" id="course-multiselect">
         <%= f.label :track_ids, "Which classes are you willing to interview students from? (all include JavaScript)" %>
         <br>
@@ -64,6 +81,11 @@
       <div class='form-group'>
         <%= f.label :address %>
         <%= f.text_field :address, class: 'form-control' %>
+      </div>
+
+      <div class='form-group'>
+        <%= f.label :interview_location, "interview location (if different)" %>
+        <%= f.text_field :interview_location, class: 'form-control' %>
       </div>
 
       <div class='form-group'>

--- a/app/views/internships/show.html.erb
+++ b/app/views/internships/show.html.erb
@@ -53,11 +53,18 @@
         <hr>
         <p><strong>Ideal intern</strong></p>
         <p><%= @internship.ideal_intern %></p>
+        <hr>
+        <p><strong>On-Site / Remote</strong></p>
+        <p>Internship is <%= @internship.remote ? "remote" : "on-site" %></p>
         <% if @internship.clearance_required %>
           <hr>
           <p><strong>Clearance description</strong></p>
           <p><%= @internship.clearance_description %></p>
         <% end %>
+        <hr>
+        <p><strong>Interview location</strong></p>
+        <p><%= @internship.interview_location && @internship.interview_location != "" ? @internship.interview_location : @internship.address %></p>
+        <hr>
       </div>
     </div>
   </div>

--- a/app/views/ratings/_internships_modal.html.erb
+++ b/app/views/ratings/_internships_modal.html.erb
@@ -19,11 +19,17 @@
               <hr>
               <p><strong>Ideal intern</strong></p>
               <p><%= internship.ideal_intern %></p>
+              <hr>
+              <p><strong>On-Site / Remote</strong></p>
+              <p>Internship is <%= internship.remote ? "remote" : "on-site" %></p>
               <% if internship.clearance_required %>
                 <hr>
                 <p><strong>Clearance description</strong></p>
                 <p><%= internship.clearance_description %></p>
               <% end %>
+              <hr>
+              <p><strong>Interview location</strong></p>
+              <p><%= internship.interview_location && internship.interview_location != "" ? internship.interview_location : internship.address %></p>
             </div>
           </div>
         </div>

--- a/db/migrate/20161229002944_add_interview_location_to_internships.rb
+++ b/db/migrate/20161229002944_add_interview_location_to_internships.rb
@@ -1,0 +1,5 @@
+class AddInterviewLocationToInternships < ActiveRecord::Migration
+  def change
+    add_column :internships, :interview_location, :string
+  end
+end

--- a/db/migrate/20161229182912_add_remote_to_internships.rb
+++ b/db/migrate/20161229182912_add_remote_to_internships.rb
@@ -1,0 +1,5 @@
+class AddRemoteToInternships < ActiveRecord::Migration
+  def change
+    add_column :internships, :remote, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161023201734) do
+ActiveRecord::Schema.define(version: 20161229182912) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,6 +108,8 @@ ActiveRecord::Schema.define(version: 20161023201734) do
     t.string   "website"
     t.string   "address"
     t.integer  "number_of_students"
+    t.string   "interview_location"
+    t.boolean  "remote"
   end
 
   create_table "interview_assignments", force: :cascade do |t|

--- a/spec/features/internship_pages_spec.rb
+++ b/spec/features/internship_pages_spec.rb
@@ -104,6 +104,20 @@ feature 'visiting the internships show page' do
     click_link internship.name
     expect(page).to have_content 'Clearance description'
   end
+
+  scenario 'interview location is shown if field has been entered' do
+    internship = FactoryGirl.create(:internship, interview_location: "test location")
+    visit internships_path(active: true)
+    click_link internship.name
+    expect(page).to have_content internship.interview_location
+  end
+
+  scenario 'company location is shown if interview location field has not been entered' do
+    internship = FactoryGirl.create(:internship)
+    visit internships_path(active: true)
+    click_link internship.name
+    expect(page).to have_content internship.address
+  end
 end
 
 feature 'viewing internships before rankings are live' do


### PR DESCRIPTION
add interview location and internship status (on-site vs remote) to company sign up / internship editing, and display that info to students when viewing and rating internships