### PR TITLE
only auto-change admin current course for teachers

### DIFF
--- a/app/views/courses/_course_list.html.erb
+++ b/app/views/courses/_course_list.html.erb
@@ -14,7 +14,11 @@
           <tbody>
             <% courses.each do |course| %>
               <tr>
-                <td><%= link_to course.description, admin_path(current_admin, admin: { current_course_id: course.id }), method: :patch %></td>
+                <% if current_admin.teacher? %>
+                  <td><%= link_to course.description, admin_path(current_admin, admin: { current_course_id: course.id }), method: :patch %></td>
+                <% else %>
+                  <td><%= link_to course.description, course_path(course) %></td>
+                <% end %>
                 <td><%= course.office.name %></td>
                 <td><%= course.teacher %></td>
                 <td><%= course.students.count %></td>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,5 +1,8 @@
 <h1>
   <%= @course.description_and_office %>
+  <% unless current_admin.current_course == @course %>
+    <%= link_to 'Select', admin_path(current_admin, admin: { current_course_id: @course.id }), method: :patch %> |
+  <% end %>
   <%= link_to 'Edit', edit_course_path(@course) %>
 </h1>
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -43,7 +43,11 @@
             <%= link_to 'Profile', edit_student_registration_path %>
           <% end %>
         <% elsif current_admin %>
-          <li><%= link_to "#{current_admin.current_course.description}", course_path(current_admin.current_course), class: 'first-navbar-link' %></li>
+          <% if current_admin.teacher? %>
+            <li><%= link_to "#{current_admin.current_course.description}", course_path(current_admin.current_course), class: 'first-navbar-link' %></li>
+          <% else %>
+            <li><%= link_to "Home", course_path(current_admin.current_course), class: 'first-navbar-link' %></li>
+          <% end %>
           <li>
             <% if current_admin.courses.any? %>
               <%= link_to 'Courses', courses_path(admin_courses: true) %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,6 +5,10 @@ FactoryGirl.define do
     password "password"
     password_confirmation "password"
     association :current_course, factory: :course
+
+    factory :teacher do
+      teacher true
+    end
   end
 
   factory :attendance_record do

--- a/spec/features/admin_pages_spec.rb
+++ b/spec/features/admin_pages_spec.rb
@@ -56,17 +56,31 @@ feature 'Admin signs in' do
   end
 end
 
-feature 'Changing current course' do
-  let(:admin) { FactoryGirl.create(:admin) }
+feature 'Changing current course for teacher' do
+  let(:teacher) { FactoryGirl.create(:teacher) }
   let(:course) { FactoryGirl.create(:course) }
 
   scenario 'admin selects a new course' do
+    course2 = FactoryGirl.create(:internship_course)
+    login_as(teacher, scope: :admin)
+    visit root_path
+    click_link 'Courses'
+    click_link course2.description
+    expect(page).to have_content "You have switched to #{course2.description}"
+  end
+end
+
+feature 'Does not change current course for non-teacher admin' do
+  let(:admin) { FactoryGirl.create(:admin) }
+  let(:course) { FactoryGirl.create(:course) }
+
+  scenario 'non-teacher admin views a course' do
     course2 = FactoryGirl.create(:internship_course)
     login_as(admin, scope: :admin)
     visit root_path
     click_link 'Courses'
     click_link course2.description
-    expect(page).to have_content "You have switched to #{course2.description}"
+    expect(page).to_not have_content "You have switched to #{course2.description}"
   end
 end
 

--- a/spec/features/course_pages_spec.rb
+++ b/spec/features/course_pages_spec.rb
@@ -166,6 +166,20 @@ feature 'visiting the course index page' do
   end
 end
 
+feature 'selecting a new course manually' do
+  let(:admin) { FactoryGirl.create(:admin) }
+
+  scenario 'as an admin' do
+    course2 = FactoryGirl.create(:internship_course)
+    login_as(admin, scope: :admin)
+    visit root_path
+    click_on 'Courses'
+    click_on course2.description
+    click_on 'Select'
+    expect(page).to have_content "You have switched to #{course2.description}"
+  end
+end
+
 feature 'exporting course students emails to a file' do
   let(:admin) { FactoryGirl.create(:admin) }
   let(:student) { FactoryGirl.create(:user_with_all_documents_signed) }


### PR DESCRIPTION
For non-teachers, allow viewing courses without re-setting admin.current_course. Allow manual updating of admin.current_course from course#show page.